### PR TITLE
:whale: Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,2 @@
+FROM python:3.9
+RUN apt-get update && apt-get install -y libusb-1.0-0 libusb-1.0-0-dev && pip install taccjm

--- a/src/taccjm/taccjm.py
+++ b/src/taccjm/taccjm.py
@@ -21,9 +21,9 @@ __author__ = "Carlos del-Castillo-Negrete"
 __copyright__ = "Carlos del-Castillo-Negrete"
 __license__ = "MIT"
 
-# Initialize logger
+# Make log dirs and initialize logger
+make_taccjm_dir()
 logger = logging.getLogger(__name__)
-
 
 def set_host(host:str=TACCJM_HOST, port:int=TACCJM_PORT) -> Tuple[str, int]:
     """


### PR DESCRIPTION
Added:
- Dockerfile for building docker image.
Fixed:
- Bug where .taccjm log directory is not created for new docker
  instances. Docker image should work now with latest version of taccjm