### PR TITLE
:bug: Fixing docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,2 +1,3 @@
 FROM python:3.9
+RUN mkdir -p ~/.taccjm
 RUN apt-get update && apt-get install -y libusb-1.0-0 libusb-1.0-0-dev && pip install taccjm


### PR DESCRIPTION
Fixed:
- For safety, have docker image needs .taccjm dir be created explicitly