### PR TITLE
Fixed job_deploy to work with config_dict and no project.ini file.

### DIFF
--- a/src/taccjm/taccjm.py
+++ b/src/taccjm/taccjm.py
@@ -844,10 +844,11 @@ def deploy_job(
 
     if job_config is not None:
         # Temp file with job config dict for sending request - deleted when closed
-        temp = tempfile.NamedTemporaryFile(mode='w+', dir=local_job_dir)
-        json.dump(job_config, temp)
-        temp.flush()
-        data['job_config_file'] = os.path.basename(temp.name)
+        #temp = tempfile.NamedTemporaryFile(mode='w+', dir=local_job_dir)
+        #json.dump(job_config, temp)
+        #temp.flush()
+        #data['job_config_file'] = os.path.basename(temp.name)
+        data['job_config'] = json.dumps(job_config)
 
     try:
         res = api_call('POST', f"{jm_id}/jobs/deploy", data)

--- a/src/taccjm/taccjm_server.py
+++ b/src/taccjm/taccjm_server.py
@@ -11,6 +11,7 @@ import os
 import hug
 import falcon
 import logging
+import json
 from typing import Union, List, Tuple
 from taccjm.TACCJobManager import TACCJobManager, TJMCommandError
 
@@ -305,6 +306,7 @@ def get_job(jm_id:str, job_id:str):
 
 @hug.post('/{jm_id}/jobs/deploy')
 def deploy_job(jm_id:str,
+               job_config:str=None,
                local_job_dir:str='.',
                job_config_file:str='job.json',
                proj_config_file:str='project.ini',
@@ -316,7 +318,8 @@ def deploy_job(jm_id:str,
     msg = f"{jm_id} - deploying job at path {local_job_dir}/{job_config_file}"
     logger.info(msg)
 
-    return JM[jm_id].deploy_job(local_job_dir=local_job_dir,
+    return JM[jm_id].deploy_job(job_config = None if job_config is None else json.loads(job_config),
+                                local_job_dir=local_job_dir,
                                 job_config_file=job_config_file,
                                 proj_config_file=proj_config_file,
                                 stage=stage,


### PR DESCRIPTION
The job_deploy method fails if just job_config is specified with no files, as the API was using a temporary file to pass the job_config. This PR changed the API to use JSON to pass the config dict instead of a temporary file, which gets around that issue.