### PR TITLE
:sparkles: Feature Improvements

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,3 +3,4 @@ Contributors
 ============
 
 * Carlos del-Castillo-Negrete <cdelcastillo21@gmail.com>
+* Benjamin Pachev <benjamin.pachev@gmail.com> 

--- a/README.rst
+++ b/README.rst
@@ -8,16 +8,10 @@ HPC resources provided by the Texas Advanced Computing Center (TACC).
 Description
 ===========
 
-TACCJM manages ssh connections to TACC systems for deploying applications,
-running jobs, and downloading/uploading data. These connections to specific
-TACC resources are maintained by a locally deployed server that exposes an
-API to access TACC resources via http endpoints. This gives the user several
-methods to establish and maintain connections to TACC resources
-programmatically and without repeated 2-factor authentication.
-Furthermore the application and job hierarchy makes it easier to create
-reproducible and shareable HPC workflows for research.
-
-.. _pyscaffold-notes:
+TACCJM manages ssh connections to TACC systems for deploying applications, running jobs, and downloading/uploading data. 
+These connections to are maintained by a locally deployed server that exposes an API to access TACC connections via http endpoints.
+This gives the user several methods to establish and maintain connections to TACC resources programmatically and without repeated 2-factor authentication.
+Furthermore the application and job hierarchy makes it easier to create reproducible and shareable HPC workflows for research.
 
 Requirements
 ============
@@ -32,21 +26,22 @@ Installation
 
 To install use pip:
 
-```
-pip install taccjm
-```
+.. code-block:: python
 
-A docker image for taccjm is in development and will hopefully be available in
-a future release.
+        pip install taccjm
 
-Getting Started
-===============
+A docker image for taccjm is in development and will hopefully be available in a future release.
 
-The easiest way to use taccjm is through
+Requirements
+============
 
+A [TACC Account](https://portal.tacc.utexas.edu/) is required to use the TACC Job Manager library. Furthermore allocations on one of the available TACC HPC systems is required to run jobs.
 
-Note
-====
+.. warning::
+
+        TACC Job Manager allows you to programmatically access TACC resources.
+        Please be responsible in your access and usage of TACC resources.
+        Review the [TACC Usage Policy](https://portal.tacc.utexas.edu/tacc-usage-policy) carefully before using any TACC resources.
 
 This project has been set up using PyScaffold 4.0.2. For details and usage
 information on PyScaffold see https://pyscaffold.org/.

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Requirements
 Using taccjm requires a TACC account enable with 2-fa. In order to run jobs
 on TACC systems as well, you will need a valid allocation associated with your
 user ID. Finally, your TACC user account needs to have 2-factor authentication
-enabled. See the [TACC user portal](https://portal.tacc.utexas.edu/)
+enabled. See the `TACC user portal <https://portal.tacc.utexas.edu/>`_
 
 Installation
 ============
@@ -35,7 +35,7 @@ A docker image for taccjm is in development and will hopefully be available in a
 Requirements
 ============
 
-A [TACC Account](https://portal.tacc.utexas.edu/) is required to use the TACC Job Manager library. Furthermore allocations on one of the available TACC HPC systems is required to run jobs.
+A `TACC user portal <https://portal.tacc.utexas.edu/>`_ is required to use the TACC Job Manager library. Furthermore allocations on one of the available TACC HPC systems is required to run jobs.
 
 .. warning::
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,7 @@ import os
 import sys
 import inspect
 import shutil
+import sphinx_rtd_theme
 
 # -- Path setup --------------------------------------------------------------
 
@@ -78,6 +79,7 @@ extensions = [
     "sphinx.ext.ifconfig",
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
+    "sphinx_rtd_theme",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -147,7 +149,7 @@ pygments_style = "sphinx"
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = "alabaster"
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,26 +2,7 @@
 taccjm
 ======
 
-This is the documentation of **taccjm**.
-
-.. note::
-
-    This is the main page of your project's `Sphinx`_ documentation.
-    It is formatted in `reStructuredText`_. Add additional pages
-    by creating rst-files in ``docs`` and adding them to the `toctree`_ below.
-    Use then `references`_ in order to link them from this page, e.g.
-    :ref:`authors` and :ref:`changes`.
-
-    It is also possible to refer to the documentation of other Python packages
-    with the `Python domain syntax`_. By default you can reference the
-    documentation of `Sphinx`_, `Python`_, `NumPy`_, `SciPy`_, `matplotlib`_,
-    `Pandas`_, `Scikit-Learn`_. You can add more by extending the
-    ``intersphinx_mapping`` in your Sphinx's ``conf.py``.
-
-    The pretty useful extension `autodoc`_ is activated by default and lets
-    you include documentation from docstrings. Docstrings can be written in
-    `Google style`_ (recommended!), `NumPy style`_ and `classical style`_.
-
+TACC Job Manager is a lightweight python library for managing HPC resources provided by the Texas Advanced Computing Center (TACC).
 
 Contents
 ========

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@
 # To build the module reference correctly, make sure every external package
 # under `install_requires` in `setup.cfg` is also listed here!
 sphinx>=3.2.1
-# sphinx_rtd_theme
+sphinx_rtd_theme

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 
 [metadata]
 name = taccjm
-description = TACC Job Manager 
+description = TACC Job Manager
 author = Carlos del-Castillo-Negrete
 author_email = cdelcastillo21@gmail.com
 license = MIT
@@ -54,6 +54,7 @@ install_requires =
     numpy<=1.21.2
     prettytable
     click
+    python-json-logger
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ install_requires =
     psutil<=5.8.0
     numpy<=1.21.2
     prettytable
+    click
 
 [options.packages.find]
 where = src
@@ -74,8 +75,8 @@ testing =
 
 [options.entry_points]
 # Add here console scripts like:
-# console_scripts =
-#     script_name = taccjm.module:function
+console_scripts =
+    taccjm = taccjm.cli.cli:cli
 # For example:
 # console_scripts =
 #     fibonacci = taccjm.skeleton:run

--- a/src/taccjm/TACCJobManager.py
+++ b/src/taccjm/TACCJobManager.py
@@ -145,9 +145,9 @@ class TACCJobManager():
         logger.info(f"Succesfuly connected to {system}")
 
         # Get taccjm working directory, relative to users scratch directory
-        logger.info("Resolving path ${self.SCRATCH_DIR} for user {self.user}")
         self.SCRATCH_DIR = scratch_dir = self._execute_command(
                 f"echo {self.SCRATCH_DIR}").strip()
+        logger.info("Resolved scratch path  to ${self.SCRATCH_DIR} for user {self.user}")
         taccjm_dir = posixpath.join(self.SCRATCH_DIR, working_dir)
 
         # Initialze jobs, apps, scripts, and trash dirs
@@ -155,6 +155,7 @@ class TACCJobManager():
         for d in zip(['jobs_dir', 'apps_dir', 'scripts_dir', 'trash_dir'],
                       ['jobs', 'apps', 'scripts', 'trash']):
             setattr(self, d[0], posixpath.join(taccjm_dir,d[1]))
+            logger.info(f"Initializing directory {getattr(self, d[0])}")
             self._mkdir(getattr(self, d[0]), parents=True)
 
         # Get python path and home dir
@@ -228,7 +229,7 @@ class TACCJobManager():
         try:
             ret = self._execute_command(cmnd)
         except TJMCommandError as tjm_error:
-            tjm_error.message = "_mkdir - Could not create directory"
+            tjm_error.message = f"_mkdir - Could not create directory {path}"
             logger.error(tjm_error.message)
             raise tjm_error
 

--- a/src/taccjm/cli/__init__.py
+++ b/src/taccjm/cli/__init__.py
@@ -1,0 +1,16 @@
+import sys
+
+if sys.version_info[:2] >= (3, 8):
+    # TODO: Import directly (no need for conditional) when `python_requires = >= 3.8`
+    from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
+else:
+    from importlib_metadata import PackageNotFoundError, version  # pragma: no cover
+
+try:
+    # Change here if project is renamed and does not equal the package name
+    dist_name = __name__
+    __version__ = version(dist_name)
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "unknown"
+finally:
+    del version, PackageNotFoundError

--- a/src/taccjm/cli/apps/__init__.py
+++ b/src/taccjm/cli/apps/__init__.py
@@ -1,0 +1,16 @@
+import sys
+
+if sys.version_info[:2] >= (3, 8):
+    # TODO: Import directly (no need for conditional) when `python_requires = >= 3.8`
+    from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
+else:
+    from importlib_metadata import PackageNotFoundError, version  # pragma: no cover
+
+try:
+    # Change here if project is renamed and does not equal the package name
+    dist_name = __name__
+    __version__ = version(dist_name)
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "unknown"
+finally:
+    del version, PackageNotFoundError

--- a/src/taccjm/cli/apps/app_commands.py
+++ b/src/taccjm/cli/apps/app_commands.py
@@ -1,0 +1,129 @@
+"""
+TACCJM Apps CLI
+"""
+import pdb
+import re
+from pathlib import Path
+
+import click
+import pandas as pd
+from prettytable import PrettyTable
+
+import taccjm.taccjm as tjm
+from taccjm.exceptions import TACCJMError
+from taccjm.utils import create_template_app, filter_res, format_app_dict, format_job_dict
+
+__author__ = "Carlos del-Castillo-Negrete"
+__copyright__ = "Carlos del-Castillo-Negrete"
+__license__ = "MIT"
+
+def _get_default():
+    jms = tjm.list_jms()
+    if len(jms) != 1:
+        raise TACCJMError('More than one or no job managers intialized.')
+    return jms[0]['jm_id']
+
+@click.group(short_help="list/get/template/deploy")
+@click.option("--jm_id", default=None,
+              help="Job Manager to execute operation on. Defaults to first available.")
+@click.pass_context
+def apps(ctx, jm_id):
+    """
+    TACC Job Manager Apps
+
+    TACCJM Application operations. If no jm_id is specified, then apps are on
+    system connected to by first job manager in a `taccjm list` operation.
+    """
+    ctx.ensure_object(dict)
+    ctx.obj['jm_id'] = jm_id
+
+@apps.command(short_help="Create template application",
+              context_settings=dict(ignore_unknown_options=True,
+                                    allow_extra_args=True))
+@click.argument("name", type=str)
+@click.option("--dest_dir", type=str, default=".", show_default=True,
+              help="Location to put application contents in.")
+@click.pass_context
+def template(ctx, name, dest_dir):
+    """
+    Create Application Template
+
+    Creates an appplication template for application with name NAME in the
+    current directory. Control destination with the --dest_dir parameter.
+    """
+    kwargs = dict([(ctx.args[i][2:], ctx.args[i+1]) for i in range(0, len(ctx.args), 2)])
+    app, job = create_template_app(name, dest_dir, **kwargs)
+    click.echo('Templated App:')
+    click.echo(format_app_dict(app))
+    click.echo('Example Job Config:')
+    click.echo(format_job_dict(job))
+
+
+@apps.command(short_help="Show deployed apps.")
+@click.option("--match", default=r".", show_default=True,
+              help="Regular expression to search job ids on.")
+@click.pass_context
+def list(ctx, match):
+    """
+    List Applications
+
+    List deployed applications on given job manager. Can search applications
+    using the --match option.
+
+    """
+    jm_id = ctx.obj['jm_id'] if ctx.obj['jm_id'] is not None else _get_default()
+    res = tjm.list_apps(jm_id)
+    str_res = filter_res([{
+        "name": r
+    } for r in res], ["name"],
+                          search="name",
+                          match=match)
+    click.echo(str_res)
+
+
+@apps.command(short_help="Show application config")
+@click.argument("app_id", type=str)
+@click.pass_context
+def get(ctx, app_id):
+    """
+    Get Application Configuration
+
+    Get configuration found in app.json file for application APP_ID deployed on
+    given TACC Job Manager.
+    """
+    jm_id = ctx.obj['jm_id'] if ctx.obj['jm_id'] is not None else _get_default()
+    res = tjm.list_apps(jm_id)
+    app_config = tjm.get_app(jm_id, app_id)
+    str_res = format_app_dict(app_config)
+    click.echo(str_res)
+
+
+@apps.command(short_help="Deploy a local application")
+@click.argument("app_dir", type=str)
+@click.option("--config_file", type=str, default="app.json", show_default=True,
+              help="Path, relative to APP_DIR, of application config file.")
+@click.option("-o/-no", "--overwrite/--no-overwrite", default=False,
+              show_default=True,
+              help="Whether to overwrite an existing application with same name if found.")
+@click.pass_context
+def deploy(ctx, app_dir, config_file, overwrite):
+    """
+    Deploy Application
+
+    Deploy an application and its contents found in APP_DIR to a TACC system.
+    Application contents are assumed to be within an 'assets' folder within
+    APP_DIR, with the application config file to be found in an 'app.json' file
+    within APP_DIR (by default).
+    """
+    jm_id = ctx.obj['jm_id'] if ctx.obj['jm_id'] is not None else _get_default()
+    app_config = tjm.deploy_app(
+        jm_id,
+        app_config=None,
+        local_app_dir=app_dir,
+        app_config_file=config_file,
+        overwrite=overwrite
+    )
+    str_res = format_app_dict(app_config)
+    click.echo(f"Application succesfully deployed to {jm_id}:")
+    click.echo(str_res)
+

--- a/src/taccjm/cli/apps/app_commands.py
+++ b/src/taccjm/cli/apps/app_commands.py
@@ -9,7 +9,7 @@ import click
 import pandas as pd
 from prettytable import PrettyTable
 
-import taccjm.taccjm as tjm
+import taccjm.taccjm_client as tjm
 from taccjm.exceptions import TACCJMError
 from taccjm.utils import create_template_app, filter_res, format_app_dict, format_job_dict
 

--- a/src/taccjm/cli/cli.py
+++ b/src/taccjm/cli/cli.py
@@ -1,0 +1,191 @@
+"""
+TACCJM CLI
+
+CLI for using TACCJM Client.
+"""
+import pdb
+import re
+import os
+from pathlib import Path
+
+import click
+import pandas as pd
+
+import taccjm.taccjm as tjm
+from taccjm.utils import filter_res
+
+from .files import file_commands as files_cli
+from .apps import app_commands as apps_cli
+from .jobs import job_commands as jobs_cli
+from .scripts import script_commands as scripts_cli
+
+__author__ = "Carlos del-Castillo-Negrete"
+__copyright__ = "Carlos del-Castillo-Negrete"
+__license__ = "MIT"
+
+TACC_PW = os.getenv('TACC_PW')
+
+# Available return fields per command
+_jm_fields = ["jm_id", "sys", "user", "apps_dir", "jobs_dir"]
+_queue_fields = [
+    "job_id",
+    "job_name",
+    "username",
+    "state",
+    "nodes",
+    "remaining",
+    "start_time",
+]
+_allocation_fields = ["name", "service_units", "exp_date"]
+
+class NaturalOrderGroup(click.Group):
+    """
+    Class For custom ordering of commands in help output
+    """
+    def list_commands(self, ctx):
+        return self.commands.keys()
+
+@click.group(cls=NaturalOrderGroup)
+@click.option("--server", type=(str, int), default=None,
+              help="Host and port of location of TACC JM server. Advanced feature, use with care.")
+def cli(server):
+    if server is not None:
+        host, port = server
+        _ = tjm.set_host(host, port)
+
+cli.add_command(apps_cli.apps)
+cli.add_command(jobs_cli.jobs)
+cli.add_command(files_cli.files)
+cli.add_command(scripts_cli.scripts)
+
+@cli.command(short_help="List active job managers")
+@click.option("-s", "--search",
+              type=click.Choice(_jm_fields, case_sensitive=False),
+              default="jm_id",
+              help="Column to search.",
+              show_default=True)
+@click.option("-m", "--match", default=r".", show_default=True,
+              help="Regular expression to match.")
+def list(search, match):
+    """
+    List TACC Job Managers
+
+    List available Job Managers on server, along with info: jm_id, system, user,
+    application directory, and jobs directory. Can filter results on any column
+    by specifying the column in the `--search` option and the regular expression
+    to match on in the `--match` option.
+    """
+    res = tjm.list_jms()
+    str_res = filter_res(res, _jm_fields, search=search, match=match)
+    click.echo(str_res)
+
+
+@cli.command(short_help="Initialize a TACC connection.")
+@click.argument("jm_id", )
+@click.argument("system")
+@click.argument("user")
+@click.option("-p", "--password", envvar='TACC_PW', default=None,
+              help='If not passed in and environment variable TACC_PW is not set, will be prompted.')
+@click.option("-m", "--mfa", default=None, help='TACC 2fa Code')
+def init(jm_id, system, user, password, mfa):
+    """
+    Initialize TACC Job Manager
+
+    Logs in USER via an ssh connection to SYSTEM and labels it with job manager
+    id JM_ID. JM_ID must be unique and not present in a `taccjm list`.
+    """
+    res = tjm.init_jm(jm_id, system, user, password, mfa)
+    str_res = filter_res([res], _jm_fields)
+    click.echo(str_res)
+
+
+@cli.command(short_help="Show SLURM job queue on JM_ID for USER.")
+@click.option("--jm_id", default=None,
+              help="Job Manager to show queue for. If none specified, then defaults to first job manager from a `taccjm list` command.")
+@click.option("--user", default=None, help="User to show job queue for. To show queue for all users, specify 'all' as the user")
+@click.option(
+    "--search",
+    type=click.Choice(_queue_fields, case_sensitive=False),
+    help="Column to search.",
+    show_default=True,
+    default="username",
+)
+@click.option("--match", default=r".", show_default=True,
+              help="Regular expression to match.")
+def queue(jm_id, user, search, match):
+    """
+    Show TACC SLURM Job Queue
+
+    Returns the active SLURM Job queue on TACC system that JM_ID is connected
+    to, with fields:\n
+        - job_id : SLURM job id. NOT TACCJM Job ID.\n
+        - job_name : SLURM job name.\n
+        - username : User that launched job.\n
+        - state : State of job.\n
+        - nodes : Nodes request.\n
+        - remaining : Time remaining in job if running.\n
+        - start_time : Start time of job.
+
+    Use `--search` and `--match` flags to filter results.
+     """
+    if jm_id is None:
+        jms = tjm.list_jms()
+        if len(jms) == 0:
+            raise TACCJMError('No JM specified (--jm_id) and no JM')
+        jm_id = tjm.list_jms()[0]['jm_id']
+    res = tjm.get_queue(jm_id, user)
+    str_res = filter_res(res, _queue_fields)
+    click.echo(f'SLURM Queue for {user} on {jm_id}:')
+    click.echo(str_res)
+
+
+@cli.command()
+@click.option("--jm_id", default=None)
+@click.option(
+    "--search",
+    type=click.Choice(_allocation_fields, case_sensitive=False),
+    help="Column to search.",
+    show_default=True,
+    default="name",
+)
+@click.option("--match", default=r".", show_default=True,
+              help="Regular expression to match.")
+def allocations(jm_id, search, match):
+    """
+    Get TACC Allocations
+
+    Return TACC allocations on system connected to by JM_ID. For each
+    allocation, returns remaining SUs.
+    """
+    if jm_id is None:
+        jms = tjm.list_jms()
+        if len(jms) == 0:
+            raise TACCJMError('No JM specified (--jm_id) and no JM')
+        jm_id = tjm.list_jms()[0]['jm_id']
+    res = tjm.get_allocations(jm_id)
+    str_res = filter_res(res, _allocation_fields, search, match)
+    click.echo(f'Allocations for {jm_id}:')
+    click.echo(str_res)
+
+@cli.command(short_help="Locate TACCJM server")
+@click.option("--start/--no-start", default=False)
+@click.option("--kill/--no-kill", default=False)
+def find_server(start, kill):
+    """
+    Find TACCJM Server
+
+    Locate (host,port) where server is running. Can kill/start server as
+    needed with appropriate flags. Note that will only show server for current
+    (host, port) being used. To change (host, port) combo, use
+    `taccjm --server hostname 1111 find-server` with appropriate host and port.
+    """
+    res = tjm.find_tjm_processes(start, kill)
+    res = [{
+        "type": x,
+        "pid": res[x].info["pid"],
+        "create_time": pd.to_datetime(res[x]._create_time, unit="s"),
+    } for x in res.keys()]
+    str_res = filter_res(res, ["type", "pid", "create_time"])
+    click.echo(str_res)
+
+

--- a/src/taccjm/cli/cli.py
+++ b/src/taccjm/cli/cli.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import click
 import pandas as pd
 
-import taccjm.taccjm as tjm
+import taccjm.taccjm_client as tjm
 from taccjm.utils import filter_res
 
 from .files import file_commands as files_cli

--- a/src/taccjm/cli/files/__init__.py
+++ b/src/taccjm/cli/files/__init__.py
@@ -1,0 +1,16 @@
+import sys
+
+if sys.version_info[:2] >= (3, 8):
+    # TODO: Import directly (no need for conditional) when `python_requires = >= 3.8`
+    from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
+else:
+    from importlib_metadata import PackageNotFoundError, version  # pragma: no cover
+
+try:
+    # Change here if project is renamed and does not equal the package name
+    dist_name = __name__
+    __version__ = version(dist_name)
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "unknown"
+finally:
+    del version, PackageNotFoundError

--- a/src/taccjm/cli/files/file_commands.py
+++ b/src/taccjm/cli/files/file_commands.py
@@ -10,7 +10,7 @@ import click
 import pandas as pd
 from prettytable import PrettyTable
 
-import taccjm.taccjm as tjm
+import taccjm.taccjm_client as tjm
 from taccjm.utils import filter_res
 
 __author__ = "Carlos del-Castillo-Negrete"

--- a/src/taccjm/cli/files/file_commands.py
+++ b/src/taccjm/cli/files/file_commands.py
@@ -1,0 +1,319 @@
+"""
+TACCJM Files CLI
+"""
+import pdb
+import re
+from stat import S_ISDIR
+from pathlib import Path
+
+import click
+import pandas as pd
+from prettytable import PrettyTable
+
+import taccjm.taccjm as tjm
+from taccjm.utils import filter_res
+
+__author__ = "Carlos del-Castillo-Negrete"
+__copyright__ = "Carlos del-Castillo-Negrete"
+__license__ = "MIT"
+
+# Available return fields per command, and their names in CLI table
+_file_fields = [
+    "filename",
+    "st_atime",
+    "st_gid",
+    "st_mode",
+    "st_mtime",
+    "st_size",
+    "st_uid",
+]
+_file_field_names = [
+    "name",
+    "is_dir",
+    "size_bytes",
+    "access_time",
+    "modified_time",
+    "uid",
+    "gid"
+]
+
+
+def _get_files_str(
+    jm_id,
+    path,
+    attrs=["name", "is_dir", "modified_time", "size_bytes"],
+    hidden=False,
+    search="name",
+    match=r".",
+    job_id=None,
+):
+    """
+    Utility function for generating string for listing files in a directory.
+    """
+    if job_id is not None:
+        res = tjm.list_job_files(jm_id,
+                                 job_id,
+                                 path,
+                                 attrs=_file_fields,
+                                 hidden=hidden)
+    else:
+        res = tjm.list_files(jm_id, path, attrs=_file_fields, hidden=hidden)
+
+    def _filt_fun(x):
+        o = {}
+        o['name'] = x['filename']
+        o['is_dir'] = True if S_ISDIR(x['st_mode']) else False
+        o['size_bytes'] = x['st_size']
+        o['access_time'] = pd.to_datetime(x["st_atime"], unit="s")
+        o['modified_time'] = pd.to_datetime(x["st_mtime"], unit="s")
+        o['uid'] = x['st_uid']
+        o['gid'] = x['st_gid']
+        return o
+
+    str_res = filter_res(res, attrs, search, match, filter_fun=_filt_fun)
+    return str_res
+
+@click.group(short_help="list/peak/download/upload/read/write/remove/restore")
+@click.option("-j", "--jm_id", default=None,
+              help="Job Manager to execute operation on. Defaults to first available.")
+@click.option("-i", "--job_id", type=str, default=None,
+              help="If specified, remote paths are taken to be relative to job directory with given id.")
+@click.pass_context
+def files(ctx, jm_id, job_id):
+    """
+    TACC Job Manager Files
+
+    File operations. If no jm_id is specified, then paths are on system
+    connected to by first job manager in a `taccjm list` operation. Remote
+    paths, if not absolute, are releative to home directory on TACC system.
+    If job_id is specified, then remote paths are relative to job directory.
+    """
+    if jm_id is None:
+        jms = tjm.list_jms()
+        if len(jms) == 0:
+            raise TACCJMError('No JM specified (--jm_id) and no JMs already initialized.')
+        jm_id = tjm.list_jms()[0]['jm_id']
+    ctx.ensure_object(dict)
+    ctx.obj['job_id'] = job_id
+    ctx.obj['jm_id'] = jm_id
+
+
+@files.command(short_help="List files.")
+@click.option("-p", "--path", type=str, default='.',
+              help="Path to list files.")
+@click.option(
+    "--attrs",
+    type=click.Choice(_file_field_names, case_sensitive=False),
+    multiple=True,
+    default=["name", "is_dir", "size_bytes", "modified_time"],
+    help="File attributes to include in output.",
+    show_default=True)
+@click.option("-h/-nh", "--hidden/--no-hidden", default=False,
+              help="Include hidden output flag.")
+@click.option(
+    "--search",
+    type=click.Choice(_file_field_names, case_sensitive=False),
+    default="name",
+    help="Column to search.",
+    show_default=True)
+@click.option("-m", "--match", default=r".", show_default=True,
+              help="Regular expression to match.")
+@click.pass_context
+def list(ctx, path, attrs, hidden, search, match):
+    """
+    List Files
+
+    List files in a given directory (defaults to home). Can search using
+    regular expressions on any given output attribute.
+    """
+    jm_id = ctx.obj['jm_id']
+    str_res = _get_files_str(jm_id,
+                             path,
+                             attrs=attrs,
+                             hidden=hidden,
+                             search=search,
+                             match=match,
+                             job_id=ctx.obj['job_id'])
+    click.echo(f'Files on {jm_id} at {path} :')
+    click.echo(str_res)
+
+
+@files.command(short_help="Show head/tail of file")
+@click.argument("path")
+@click.option("-h", "--head", type=int, default=-1,
+              help="If specified, number of lines from top of file to show.")
+@click.option("-t", "--tail", type=int, default=-1,
+              help="If specified, number of lines from bottom of file to show. Note: if head also specified, tail ignored.")
+@click.pass_context
+def peak(ctx, path, head, tail):
+    """
+    Peak File
+
+    "Peak" at file via head/tail commands. Defaults to head command (first 10
+    lines) if no options specified. Otherwise defaults to head number if head
+    specified, and tail number otherwise (if specified). File is assumed to be
+    text file. Output of operation is returned.
+    """
+    jm_id = ctx.obj['jm_id']
+    job_id = ctx.obj['job_id']
+    if job_id is None:
+        res = tjm.peak_file(jm_id, path, head, tail)
+    else:
+        res = tjm.peak_job_file(jm_id, job_id, path, head, tail)
+    pre = f"Last {tail}" if tail > 0 else f"First {head if head > 0 else 10}"
+    click.echo(f'{pre} line(s) of {path} on {jm_id} :')
+    click.echo(res)
+
+
+@files.command(short_help="Send a local file or directory.")
+@click.argument("local_path")
+@click.argument("remote_path")
+@click.option("--file_filter", type=str, default="*",
+              help="If LOCAL_PATH specifies a directory, glob string to filter files on.")
+@click.pass_context
+def upload(ctx, local_path, remote_path, file_filter):
+    """
+    Upload File or Directory
+
+    Upload a local file or a directory at LOCAL_PATH to REMOTE_PATH on TACC
+    system. Note that this is meant for relatively small (<100Mb) uploads. If a
+    directory is specified, the contents are compressed first into a sinlge file
+    before being sent, and then de-compressed on the target system. Note this
+    means that if the upload fails for some reason, some cleanup may be required
+    on the local/remote system (feature to check for/cleanup automatically is
+    coming...).
+
+    """
+    jm_id = ctx.obj['jm_id']
+    job_id = ctx.obj['job_id']
+    if job_id is None:
+        res = tjm.upload(jm_id, local_path, remote_path, file_filter)
+        str_res = _get_files_str(jm_id, str(Path(remote_path).parent),
+                                 match=str(Path(remote_path).name))
+    else:
+        res = tjm.upload_job_file(jm_id, job_id, local_path, remote_path, file_filter)
+        str_res = _get_files_str(jm_id,
+                                 "",
+                                 match=str(Path(remote_path).name),
+                                 job_id=job_id)
+    click.echo(str_res)
+
+
+@files.command(short_help="Get a remote file or directory")
+@click.argument("remote_path")
+@click.argument("local_path")
+@click.option("--file_filter", type=str, default="*",
+              help="If REMOTE_PATH specifies a directory, glob string to filter files on.")
+@click.pass_context
+def download(ctx, remote_path, local_path, file_filter):
+    """
+    Download File or Directory
+
+    Download a remote file or directory at REMOTE_PATH on TACC system to the
+    specified LOCAL_PATH. Note that this is meant for relatively small (<100Mb)
+    downloads. If a job_id was specified for this file operation, contents will
+    always be downloaded into a folder with the name of the job_id. Furthermore
+    REMOTE_PATH is assumed to be relative to a user's home directory, unless
+    job_id is specified, in which case the path is assumed to be relative to the
+    job directory. If a directory is specified, contents are compressed before
+    downloaded, and then unpacked locally. Note this means that if download
+    fails for some reason, some cleanup may be required (feature to check
+    for/cleanup automatically coming...)
+    """
+    jm_id = ctx.obj['jm_id']
+    job_id = ctx.obj['job_id']
+    if job_id is None:
+        res = tjm.download(jm_id, remote_path, local_path, file_filter)
+    else:
+        res = tjm.download_job_file(jm_id, job_id, remote_path, local_path,
+                                    file_filter)
+
+@files.command(short_help="Send a remote file/directory to trash.")
+@click.argument("remote_path")
+@click.pass_context
+def remove(ctx, remote_path):
+    """
+    Remove file/directory
+
+    Remove file or directory at REMOTE_PATH by sending it to the trash directory
+    managed by job manager. Note file can be restored with the restore command.
+    """
+    jm_id = ctx.obj['jm_id']
+    res = tjm.remove(jm_id, remote_path)
+    str_res = _get_files_str(jm_id, str(Path(remote_path).parent),
+                             match=str(Path(remote_path).name))
+    click.echo(str_res)
+
+
+@files.command(short_help="Restore a remote file/directory from trash.")
+@click.argument("remote_path")
+@click.pass_context
+def restore(ctx, remote_path):
+    """
+    Restore file/directory
+
+    Restore a file or directory at REMOTE_PATH by moving from the trash
+    directory managed by job manager back to its original location.
+    """
+    jm_id = ctx.obj['jm_id']
+    res = tjm.restore(jm_id, remote_path)
+    str_res = _get_files_str(jm_id,
+                             str(Path(remote_path).parent),
+                             match=str(Path(remote_path).name))
+    click.echo(str_res)
+
+
+@files.command(short_help="Stream data directly to a remote file.")
+@click.argument("remote_path", type=str)
+@click.argument("data", type=str)
+@click.pass_context
+def write(ctx, data, remote_path):
+    """
+    Write Data
+
+    Write string DATA directly to a file on a remote system. WARNING: Will
+    overwrite existing file. REMOTE_PATH is assumed to be relative to a user's
+    home directory, unless job_id is specified, in which case the path is
+    assumed to be relative to the job directory.
+    """
+    jm_id = ctx.obj['jm_id']
+    job_id = ctx.obj['job_id']
+    if job_id is None:
+        res = tjm.write(jm_id, data, remote_path)
+        str_res = _get_files_str(jm_id,
+                                 str(Path(remote_path).parent),
+                                 match=str(Path(remote_path).name))
+    else:
+        res = tjm.write_job_file(jm_id, job_id, data, remote_path)
+        str_res = _get_files_str(jm_id,
+                                 str(Path(remote_path).parent),
+                                 match=str(Path(remote_path).name),
+                                 job_id=job_id)
+    click.echo(str_res)
+
+
+@files.command(short_help="Stream data directly from a remote file.")
+@click.argument("remote_path", type=str)
+@click.option(
+    "--data_type",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    help="Type of data assumed to be in remote file.",
+    show_default=True)
+@click.pass_context
+def read(ctx, remote_path, data_type):
+    """
+    Read Data
+
+    Read data directly from REMOTE_PATH to stdout. REMOTE_PATH is assumed to be
+    relative to a user's home directory, unless job_id is specified, in which
+    case the path is assumed to be relative to the job directory.
+    """
+    jm_id = ctx.obj['jm_id']
+    job_id = ctx.obj['job_id']
+    if job_id is None:
+        res = tjm.read(jm_id, remote_path, data_type)
+    else:
+        res = tjm.read_job_file(jm_id, job_id, path, data_type)
+    click.echo(res)
+

--- a/src/taccjm/cli/jobs/__init__.py
+++ b/src/taccjm/cli/jobs/__init__.py
@@ -1,0 +1,16 @@
+import sys
+
+if sys.version_info[:2] >= (3, 8):
+    # TODO: Import directly (no need for conditional) when `python_requires = >= 3.8`
+    from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
+else:
+    from importlib_metadata import PackageNotFoundError, version  # pragma: no cover
+
+try:
+    # Change here if project is renamed and does not equal the package name
+    dist_name = __name__
+    __version__ = version(dist_name)
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "unknown"
+finally:
+    del version, PackageNotFoundError

--- a/src/taccjm/cli/jobs/job_commands.py
+++ b/src/taccjm/cli/jobs/job_commands.py
@@ -9,7 +9,7 @@ import click
 import pandas as pd
 from prettytable import PrettyTable
 
-import taccjm.taccjm as tjm
+import taccjm.taccjm_client as tjm
 from taccjm.exceptions import TACCJMError
 from taccjm.utils import filter_res, format_job_dict
 

--- a/src/taccjm/cli/jobs/job_commands.py
+++ b/src/taccjm/cli/jobs/job_commands.py
@@ -1,0 +1,145 @@
+"""
+TACCJM Jobs CLI
+"""
+import pdb
+import re
+from pathlib import Path
+
+import click
+import pandas as pd
+from prettytable import PrettyTable
+
+import taccjm.taccjm as tjm
+from taccjm.exceptions import TACCJMError
+from taccjm.utils import filter_res, format_job_dict
+
+__author__ = "Carlos del-Castillo-Negrete"
+__copyright__ = "Carlos del-Castillo-Negrete"
+__license__ = "MIT"
+
+def _get_default():
+    jms = tjm.list_jms()
+    if len(jms) != 1:
+        raise TACCJMError('More than one or no job managers intialized.')
+    return jms[0]['jm_id']
+
+@click.group(short_help="list/deploy/submit/cancel/remove/restore")
+@click.option("--jm_id", default=None,
+              help="Job Manager to execute operation on. Defaults to first available.")
+@click.pass_context
+def jobs(ctx, jm_id):
+    """
+    TACC Job Manager Jobs
+
+    TACCJM Job operations. If no jm_id is specified, then jobs are on system
+    connected to by first job manager in a `taccjm list` operation.
+    """
+    ctx.ensure_object(dict)
+    ctx.obj['jm_id'] = jm_id
+
+@jobs.command(short_help="List jobs deployed.")
+@click.option("--match", default=r".", show_default=True,
+              help="Regular expression to search job ids on.")
+@click.pass_context
+def list(ctx, match):
+    """
+    List jobs
+
+    List jobs deployed on job manager. Can filter results using --match option.
+    """
+    jm_id = ctx.obj['jm_id'] if ctx.obj['jm_id'] is not None else _get_default()
+    res = [{"job_id": j} for j in tjm.list_jobs(jm_id)]
+    str_res = filter_res(res, ["job_id"], search="job_id", match=match)
+    click.echo(str_res)
+
+
+@jobs.command(short_help="Deploy a job",
+              context_settings=dict(ignore_unknown_options=True,
+                                    allow_extra_args=True))
+@click.option("--config_file", type=str, default="job.json", show_default=True,
+              help="Path to job config json file.")
+@click.option("-s/-ns", "--stage/--no-stage", default=False, show_default=True,
+              help="Whether to actually stage the job on the remote system.")
+@click.pass_context
+def deploy(ctx, config_file, stage):
+    """
+    Deploy Job
+
+    Deploy a job to a remote system. Job config is assume to be in a json file
+    with the name `job.json`. Change path to json file with --config_file.
+    Prints job config.
+    """
+    kwargs = dict([(ctx.args[i][2:], ctx.args[i+1]) for i in range(0, len(ctx.args), 2)])
+    jm_id = ctx.obj['jm_id'] if ctx.obj['jm_id'] is not None else _get_default()
+    job = tjm.deploy_job(
+        jm_id,
+        job_config=None,
+        local_job_dir=str(Path(config_file).absolute().parent),
+        job_config_file=str(Path(config_file).name),
+        stage=stage,
+        **kwargs
+    )
+    str_res = format_job_dict(job)
+    click.echo(str_res)
+
+
+@jobs.command(short_help="Submit job to SLURM job queue.")
+@click.argument("job_id", type=str)
+@click.pass_context
+def submit(ctx, job_id):
+    """
+    Submit Job
+
+    Submits a job JOB_ID to SLURM queue. Note job must be deployed first to be
+    submitted.
+    """
+    jm_id = ctx.obj['jm_id'] if ctx.obj['jm_id'] is not None else _get_default()
+    job = tjm.submit_job(jm_id, job_id)
+    str_res = format_job_dict(job)
+    click.echo(str_res)
+
+
+@jobs.command(short_help="Cancel job in SLURM job queue.")
+@click.argument("job_id", type=str)
+@click.pass_context
+def cancel(ctx, job_id):
+    """
+    Cancel Job
+
+    Cancel a job JOB_ID that has been submitted to the SLURM task queue.
+    """
+    jm_id = ctx.obj['jm_id'] if ctx.obj['jm_id'] is not None else _get_default()
+    job = tjm.cancel_job(jm_id, job_id)
+    str_res = format_job_dict(job)
+    click.echo(str_res)
+
+
+@jobs.command(short_help="Send a job directory to trash.")
+@click.argument("job_id", type=str)
+@click.pass_context
+def remove(ctx, job_id):
+    """
+    Remove Job
+
+    Delete job JOB_ID from job directory by moving it to the trash directory.
+    Note the job can be restored still with the restore command.
+    """
+    jm_id = ctx.obj['jm_id'] if ctx.obj['jm_id'] is not None else _get_default()
+    _ = tjm.remove_job(jm_id, job_id)
+    click.echo(f'Job {job_id} succsefully moved to trash')
+
+@jobs.command(short_help="Restore job directory from trash.")
+@click.argument("job_id", type=str)
+@click.pass_context
+def restore(ctx, job_id):
+    """
+    Restore Job
+
+    Restore JOB_ID that has been moved to the trash directory previously via
+    a remove command.
+    """
+    jm_id = ctx.obj['jm_id'] if ctx.obj['jm_id'] is not None else _get_default()
+    job = tjm.restore_job(jm_id, job_id)
+    str_res = format_job_dict(job)
+    click.echo(str_res)
+

--- a/src/taccjm/cli/scripts/__init__.py
+++ b/src/taccjm/cli/scripts/__init__.py
@@ -1,0 +1,16 @@
+import sys
+
+if sys.version_info[:2] >= (3, 8):
+    # TODO: Import directly (no need for conditional) when `python_requires = >= 3.8`
+    from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
+else:
+    from importlib_metadata import PackageNotFoundError, version  # pragma: no cover
+
+try:
+    # Change here if project is renamed and does not equal the package name
+    dist_name = __name__
+    __version__ = version(dist_name)
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "unknown"
+finally:
+    del version, PackageNotFoundError

--- a/src/taccjm/cli/scripts/script_commands.py
+++ b/src/taccjm/cli/scripts/script_commands.py
@@ -1,0 +1,100 @@
+"""
+TACCJM Scripts CLI
+"""
+import pdb
+import re
+from pathlib import Path
+
+import click
+import pandas as pd
+from prettytable import PrettyTable
+
+import taccjm.taccjm as tjm
+from taccjm.exceptions import TACCJMError
+from taccjm.utils import filter_res
+
+__author__ = "Carlos del-Castillo-Negrete"
+__copyright__ = "Carlos del-Castillo-Negrete"
+__license__ = "MIT"
+
+@click.group(short_help="list/deploy/run")
+@click.option("-j", "--jm_id", default=None,
+              help="Job Manager to execute operation on. Defaults to first available.")
+@click.pass_context
+def scripts(ctx, jm_id):
+    """
+    TACC Job Manager Scripts
+
+    CLI Entrypoint for commands related to scripts.
+    """
+    if jm_id is None:
+        jms = tjm.list_jms()
+        if len(jms) == 0:
+            raise TACCJMError('No JM specified (--jm_id) and no JMs already initialized.')
+        jm_id = tjm.list_jms()[0]['jm_id']
+    ctx.ensure_object(dict)
+    ctx.obj['jm_id'] = jm_id
+
+
+@scripts.command(short_help="List deployed scripts.")
+@click.option("-m", "--match", default=r".", show_default=True,
+              help="Regular expression to search script names for.")
+@click.pass_context
+def list(ctx, match):
+    """
+    List scripts deployed on JM_ID
+    """
+    jm_id = ctx.obj['jm_id']
+    res = tjm.list_scripts(jm_id)
+    str_res = filter_res([{
+        "name": x
+    } for x in res], ["name"],
+                          search="name",
+                          match=match)
+    click.echo(str_res)
+
+
+@scripts.command(short_help="Deploy a local script.")
+@click.argument("path")
+@click.option("-r", "--rename", default=None,
+              help="Name to give to deployed script. Defaults to script file name.")
+@click.pass_context
+def deploy(ctx, path, rename):
+    """
+    Deploy Script
+
+    Deploy a local script onto a TACC system.
+    """
+    jm_id = ctx.obj['jm_id']
+    if rename is None:
+        script_name = str(Path(path).stem)
+        res = tjm.deploy_script(jm_id, path)
+    else:
+        script_name = str(Path(rename).stem)
+        res = tjm.deploy_script(jm_id, rename, local_file=path)
+    res = tjm.list_scripts(jm_id)
+    str_res = filter_res([{
+        "name": x
+    } for x in res], ["name"],
+                          search="name",
+                          match=script_name)
+    click.echo(str_res)
+
+
+@scripts.command(short_help="Run deployed script.")
+@click.argument("script", type=str)
+@click.argument("args", nargs=-1, default=None)
+@click.pass_context
+def run(ctx, script, args):
+    """
+    Run Deployed Script
+
+    Run SCRIPT on JM_ID with passed in ARGS. SCRIPT must have been deployed
+    already on JM_ID. Returns stdout. Take care with scripts that output a large
+    amount of data. It is better practice for large output to be sent to a log
+    file and for that to be downloaded seperately.
+    """
+    jm_id = ctx.obj['jm_id']
+    res = tjm.run_script(jm_id, script, args=args)
+    click.echo(res)
+

--- a/src/taccjm/cli/scripts/script_commands.py
+++ b/src/taccjm/cli/scripts/script_commands.py
@@ -9,7 +9,7 @@ import click
 import pandas as pd
 from prettytable import PrettyTable
 
-import taccjm.taccjm as tjm
+import taccjm.taccjm_client as tjm
 from taccjm.exceptions import TACCJMError
 from taccjm.utils import filter_res
 

--- a/src/taccjm/constants.py
+++ b/src/taccjm/constants.py
@@ -31,10 +31,7 @@ APP_TEMPLATE = {'name': 'template-app',
                             'desc': 'Input to be copied to job dir.'}],
                 'parameters': [{'name': 'param1',
                                 'label': 'Parameter argument',
-                                'desc': 'value to be parsed into run script'}],
-                'outputs': [{'name': 'output1',
-                             'label': 'Output',
-                             'desc': 'Output produced by application.'}]}
+                                'desc': 'value to be parsed into run script'}]}
 JOB_TEMPLATE = {'name': 'template-app-job-test',
                 'app': 'template-app',
                 'desc': 'A test run of the tempalte hpc application.',

--- a/src/taccjm/constants.py
+++ b/src/taccjm/constants.py
@@ -17,40 +17,14 @@ TACCJM_HOST = 'localhost'
 
 # Basic HPC Application Template
 
-# Example Project Config (.ini) file. Values to be added into app/job configs
-CONFIG_TEMPLATE = """[app]
-# These values will be templated into app json file.
-name = template-app
-version = 0.0.0
-short_desc = Template Application
-long_description = Template to build HPC apps.
-
-# Assume we are using this app on TACC stampede2
-queue = development
-
-[job]
-# Can also specify job parameters here
-desc = A test run of the template hpc application
-
-# Note job queue may change depending on what system application is on
-queue = development
-
-# Test input file from local system to send to job
-input = input.txt
-
-# Test job parameter to be passed to job run
-parameter = 1
-"""
-
-# Example APP and JOB configs, with jinja template string patterns
-APP_TEMPLATE = {'name': '{{ app.name }}--{{ app.version }}',
-                'short_desc': '{{ app.short_desc }}',
-                'long_desc':  '{{ app.long_desc }}',
+# Example APP and JOB configs
+APP_TEMPLATE = {'name': 'template-app',
+                'short_desc': 'Template Application',
+                'long_desc':  'Template to build HPC Apps',
                 'default_node_count': 1,
                 'default_processors_per_node': 10,
-                'default_memory_per_node': '1',
                 'default_max_run_time': '00:10:00',
-                'default_queue': '{{ app.queue }}',
+                'default_queue': 'development',
                 'entry_script': 'run.sh',
                 'inputs': [{'name': 'input1',
                             'label': 'Input argument',
@@ -61,16 +35,16 @@ APP_TEMPLATE = {'name': '{{ app.name }}--{{ app.version }}',
                 'outputs': [{'name': 'output1',
                              'label': 'Output',
                              'desc': 'Output produced by application.'}]}
-JOB_TEMPLATE = {'name': '{{ app.name }}-job-test',
-                'app': '{{ app.name }}--{{ app.version}}',
-                'desc': '{{ job.desc }}',
-                'queue': '{{ job.queue }}',
+JOB_TEMPLATE = {'name': 'template-app-job-test',
+                'app': 'template-app',
+                'desc': 'A test run of the tempalte hpc application.',
+                'queue': 'development',
                 'node_count': 1,
                 'processors_per_node': 2,
                 'memory_per_node': '1',
                 'max_run_time': '00:01:00',
-                'inputs': {'input1': '{{ job.input }}'},
-                'parameters': {'param1': '{{ job.parameter }}'}}
+                'inputs': {'input1': 'input.txt'},
+                'parameters': {'param1': '1'}}
 
 # Example of an application entry point script.
 APP_SCRIPT_TEMPLATE = """#### BEGIN SCRIPT LOGIC

--- a/src/taccjm/taccjm.py
+++ b/src/taccjm/taccjm.py
@@ -733,7 +733,6 @@ def deploy_app(
         app_config:dict=None,
         local_app_dir:str='.',
         app_config_file:str='app.json',
-        proj_config_file:str='project.ini',
         overwrite:bool=False,
         **kwargs):
     """
@@ -752,11 +751,6 @@ def deploy_app(
         system.
     app_config_file: str, default='app.json'
         Path relative to local_app_dir containing app config json file.
-    proj_config_file : str, default='project.ini'
-        Path, relative to local_app_dir, to project config .ini file. Only
-        used if job_config not specified. If used, jinja is used to
-        substitue values found in config file into the job json file.
-        Useful for templating jobs.
     overwrite : bool, default=False
         Whether to overwrite application on remote system if it already exists
         (same application name and version).
@@ -774,7 +768,6 @@ def deploy_app(
     # Build data for request. Some of these may be None/default
     data = {'local_app_dir':os.path.abspath(local_app_dir),
             'app_config_file':app_config_file,
-            'proj_config_file':proj_config_file,
             'overwrite':overwrite}
 
     # TODO: Check for valid kwargs params to update for app
@@ -857,14 +850,12 @@ def deploy_job(
         job_config:dict=None,
         local_job_dir:str='.',
         job_config_file:str='job.json',
-        proj_config_file:str='project.ini',
         stage:bool=True,
         **kwargs) -> dict:
     """
     Setup job directory on supercomputing resources. If job_config is not
     specified, then it is parsed from the json file found at
-    local_job_dir/job_config_file, with jinja templated values from the
-    local_job_dir/proj_config_file substituted in accordingly. In either
+    local_job_dir/job_config_file. In either
     case, values found in dictionary or in parsed json file can be
     overrided by passing keyword arguments. Note for dictionary values,
     only the specific keys in the dictionary value specified will be
@@ -881,11 +872,6 @@ def deploy_job(
     job_config_file : str, default='job.json'
         Path, relative to local_job_dir, to job config json file. File
         only read if job_config dictionary not given.
-    proj_config_file : str, default='project.ini'
-        Path, relative to local_job_dir, to project config .ini file. Only
-        used if job_config not specified. If used, jinja is used to
-        substitue values found in config file into the job json file.
-        Useful for templating jobs.
     stage : bool, default=False
         If set to True, stage job directory by creating it, moving
         application contents, moving job inputs, and writing submit_script
@@ -908,7 +894,6 @@ def deploy_job(
     # Build data for request. Some of these may be None/default
     data = {'local_job_dir':local_job_dir,
             'job_config_file':job_config_file,
-            'proj_config_file':proj_config_file,
             'stage':stage}
 
     # TODO: Check for valid kwargs params to update for job

--- a/src/taccjm/taccjm.py
+++ b/src/taccjm/taccjm.py
@@ -1380,3 +1380,4 @@ def empty_trash(jm_id:str, filter_str:str='*') -> None:
     data = {'filter_str': filter_str}
 
     api_call('DELETE', f"{jm_id}/trash/empty", data)
+

--- a/src/taccjm/taccjm_client.py
+++ b/src/taccjm/taccjm_client.py
@@ -4,6 +4,7 @@ TACCJM Client
 Client for managing TACCJM hug servers and accessing TACCJM API end points.
 """
 import os
+import sys
 import pdb
 import re
 from prettytable import PrettyTable
@@ -15,7 +16,7 @@ import tempfile
 import subprocess
 from time import sleep
 from getpass import getpass
-from taccjm.constants import *
+from taccjm.constants import make_taccjm_dir, TACCJM_HOST, TACCJM_PORT, TACCJM_SOURCE, TACCJM_DIR
 from typing import List, Tuple
 from taccjm.exceptions import TACCJMError
 
@@ -153,7 +154,7 @@ def find_tjm_processes(start:bool=False, kill:bool=False) -> dict:
     # Strings defining commands
     srv_cmd = f"hug -ho {TACCJM_HOST} -p {TACCJM_PORT} -f "
     srv_cmd += os.path.join(TACCJM_SOURCE, 'taccjm_server.py')
-    hb_cmd = "python "+os.path.join(TACCJM_SOURCE, 'taccjm_server_heartbeat.py')
+    hb_cmd = f"python {os.path.join(TACCJM_SOURCE, 'taccjm_server_heartbeat.py')}"
     hb_cmd += f" --host={TACCJM_HOST} --port={TACCJM_PORT}"
 
     for proc in psutil.process_iter(['name', 'pid', 'cmdline']):

--- a/src/taccjm/taccjm_server.py
+++ b/src/taccjm/taccjm_server.py
@@ -271,7 +271,6 @@ def get_app(jm_id:str, app_id:str):
 def deploy_app(jm_id:str,
                local_app_dir:str='.',
                app_config_file:str="app.json",
-               proj_config_file:str="project.ini",
                overwrite:bool=False) -> dict:
     """Deploy App
 
@@ -285,7 +284,6 @@ def deploy_app(jm_id:str,
     return JM[jm_id].deploy_app(
                 local_app_dir=local_app_dir,
                 app_config_file=app_config_file,
-                proj_config_file=proj_config_file,
                 overwrite=overwrite)
 
 
@@ -314,7 +312,6 @@ def deploy_job(jm_id:str,
                job_config:str=None,
                local_job_dir:str='.',
                job_config_file:str='job.json',
-               proj_config_file:str='project.ini',
                stage:bool=True,
                **kwargs):
     """ Deploy a job to TACC system. """
@@ -326,7 +323,6 @@ def deploy_job(jm_id:str,
     return JM[jm_id].deploy_job(job_config = None if job_config is None else json.loads(job_config),
                                 local_job_dir=local_job_dir,
                                 job_config_file=job_config_file,
-                                proj_config_file=proj_config_file,
                                 stage=stage,
                                 **kwargs)
 

--- a/src/taccjm/utils.py
+++ b/src/taccjm/utils.py
@@ -4,12 +4,15 @@ TACCJobManager Utility Function
 
 """
 
+import pdb
 import os                       # OS system utility functions
+import re
 import json                     # For reading/writing dictionary<->json
 import errno                    # For error messages
 import configparser             # For reading configs
 from typing import Tuple        # For type hinting
 from taccjm.constants import JOB_TEMPLATE, APP_TEMPLATE, APP_SCRIPT_TEMPLATE
+from prettytable import PrettyTable
 
 __author__ = "Carlos del-Castillo-Negrete"
 __copyright__ = "Carlos del-Castillo-Negrete"
@@ -77,6 +80,9 @@ def create_template_app(name:str,
     """
     # Update app template dictionary with passed in arguments
     app_config.update(kwargs)
+    app_config['name'] = name
+    job_config['app'] = name
+    job_config['name'] = f'{name}-test-job'
 
     # Create application directory - Fails if already exists
     app_dir = os.path.join(dest_dir, name)
@@ -102,4 +108,68 @@ def create_template_app(name:str,
 
     return (app_config, job_config)
 
+
+def filter_res(res, fields, search=None, match=r".", filter_fun=None):
+    """
+    Print results
+
+    Prints dictionary keys in list `fields` for each dictionary in res,
+    filtering on the search column if specified with regular expression
+    if desired.
+
+    Parameters
+    ----------
+    res : List[dict]
+        List of dictionaries containing response of an AgavePy call
+    fields : List[string]
+        List of strings containing names of fields to extract for each element.
+    search : string, optional
+        String containing column to perform string patter matching on to
+        filter results.
+    match : str, default='.'
+        Regular expression to match strings in search column.
+    output_file : str, optional
+        Path to file to output result table to.
+
+    """
+    # Initialize Table
+    x = PrettyTable(float_format="0.2")
+    x.field_names = fields
+
+    # Build table from results
+    filtered_res = []
+    for r in res:
+        if filter_fun is not None:
+            r = filter_fun(r)
+        if search is not None:
+            if re.search(match, r[search]) is not None:
+                x.add_row([r[f] for f in fields])
+                filtered_res.append(dict([(f, r[f]) for f in fields]))
+        else:
+            x.add_row([r[f] for f in fields])
+            filtered_res.append(dict([(f, r[f]) for f in fields]))
+
+    return str(x)
+
+def format_app_dict(app):
+    res = [{'attr':x, 'val': app[x]} for x in app.keys()]
+    def _filter_fun(x):
+        if x['attr'] in ['inputs', 'parameters', 'outputs']:
+            if len(x['val']) > 0:
+                x['val'] = filter_res(x['val'], ['name', 'desc'])
+            else:
+                x['val'] = ''
+        return x
+    str_res = filter_res(res, ['attr', 'val'], filter_fun=_filter_fun)
+    return str_res
+
+def format_job_dict(job):
+    res = [{'attr':x, 'val': job[x]} for x in job.keys()]
+    def _filter_fun(x):
+        if x['attr'] in ['inputs', 'parameters']:
+            val_list = [{'name': x[0], 'value':x[1]} for x in x['val'].items()]
+            x['val'] = filter_res(val_list, ['name', 'value'])
+        return x
+    str_res = filter_res(res, ['attr', 'val'], filter_fun=_filter_fun)
+    return str_res
 

--- a/src/taccjm/utils.py
+++ b/src/taccjm/utils.py
@@ -8,9 +8,8 @@ import os                       # OS system utility functions
 import json                     # For reading/writing dictionary<->json
 import errno                    # For error messages
 import configparser             # For reading configs
-from jinja2 import Template     # For templating input json files
 from typing import Tuple        # For type hinting
-from taccjm.constants import *  # Library constants
+from taccjm.constants import JOB_TEMPLATE, APP_TEMPLATE, APP_SCRIPT_TEMPLATE
 
 __author__ = "Carlos del-Castillo-Negrete"
 __copyright__ = "Carlos del-Castillo-Negrete"
@@ -45,59 +44,10 @@ def update_dic_keys(d:dict, **kwargs) -> dict:
 
     return d
 
-
-def load_templated_json_file(path:str, config_path:str, **kwargs) -> dict:
-    """
-    Loads a local json config found at path and templates it using jinja with
-    the values found in config ini file found at config_path . For example, if
-    json file contains `{{ a.b }}`, and `config={'a':{'b':1}}`, then `1` would
-    be substituted in (note nesting). All extra keyword arguments will be
-    interpreted as job config overrides.
-
-    Parameters
-    ----------
-    path : str
-        Local path to json file.
-    config_path : str
-        Path to config file (.ini)
-    **kwargs : dict, optional
-        Any extra keyword arguments will be interpreted as items to override in
-        from the loaded json config file.
-
-    Returns
-    -------
-    json_config : dict
-        json config from file templated appropriately.
-
-    Raises
-    ------
-    FileNotFoundError
-        if json or config file do not exist.
-
-    """
-    # Check if it exists - If it doesn't config parser won't error
-    if not os.path.exists(config_path):
-        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT),
-                config_path)
-
-    # Read project config file
-    config_parse = configparser.ConfigParser()
-    config_parse.read(config_path)
-    config = config_parse._sections
-
-    with open(path) as file_:
-        json_config = json.loads(Template(file_.read()).render(config))
-
-    # Treat kwargs as override parameters
-    json_config = update_dic_keys(json_config, **kwargs)
-
-    # Return json_config
-    return json_config
-
-
 def create_template_app(name:str,
         dest_dir:str='.',
-        app_template:dict=APP_TEMPLATE,
+        app_config:dict=APP_TEMPLATE,
+        job_config:dict=JOB_TEMPLATE,
         script:str=APP_SCRIPT_TEMPLATE,
         **kwargs) -> Tuple[dict, dict]:
     """
@@ -126,7 +76,7 @@ def create_template_app(name:str,
         If application with given name already exists in local directory.
     """
     # Update app template dictionary with passed in arguments
-    app_template.update(kwargs)
+    app_config.update(kwargs)
 
     # Create application directory - Fails if already exists
     app_dir = os.path.join(dest_dir, name)
@@ -136,28 +86,19 @@ def create_template_app(name:str,
     assets_dir = os.path.join(app_dir, 'assets')
     os.mkdir(assets_dir)
 
-    # Write project config file
-    config_path = os.path.join(app_dir, 'project.ini')
-    with open(config_path, 'w') as f:
-        f.write(CONFIG_TEMPLATE)
-
     # Write app config json file
     app_config_path = os.path.join(app_dir, 'app.json')
     with open(app_config_path, 'w') as f:
-        json.dump(app_template, f)
+        json.dump(app_config, f)
 
     # Write job config json file
     job_config_path = os.path.join(app_dir, 'job.json')
     with open(job_config_path, 'w') as f:
-        json.dump(JOB_TEMPLATE, f)
+        json.dump(job_config, f)
 
     # Write entry point script
     with open(os.path.join(assets_dir, 'run.sh'), 'w') as f:
-        f.write(APP_SCRIPT_TEMPLATE)
-
-    # Load in app and job config from templates as they were created
-    app_config = load_templated_json_file(app_config_path, config_path)
-    job_config = load_templated_json_file(job_config_path, config_path)
+        f.write(script)
 
     return (app_config, job_config)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,6 @@ def pytest_addoption(parser):
     parser.addoption("--mfa", action="store",
             default="012345", help="MFA token. Must be provided")
 
-
 @pytest.fixture
 def mfa(request):
     return request.config.getoption("--mfa")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,328 @@
+"""
+Tests for taccjm
+
+TODO: Pytest fixture for clean test-taccjm on remote system
+
+"""
+import os
+import pdb
+import json
+import stat
+import psutil
+import pytest
+import posixpath
+from dotenv import load_dotenv
+from pathlib import Path
+import shutil
+from click.testing import CliRunner
+
+from taccjm.cli.cli import cli
+
+__author__ = "Carlos del-Castillo-Negrete"
+__copyright__ = "Carlos del-Castillo-Negrete"
+__license__ = "MIT"
+
+# Note: .env file in tests directory must contain
+#   - TACC_USER
+#   - TACC_PW
+#   - TACC_SYSTEM
+#   - TACC_ALLOCATION
+load_dotenv()
+
+# Globals loaded from .env config file in tests directory
+# Used for connecting to TACC system for integration tests
+global SYSTEM, USER, PW, SYSTEM, ALLOCATION
+USER = os.environ.get("TACCJM_USER")
+PW = os.environ.get("TACCJM_PW")
+SYSTEM = os.environ.get("TACCJM_SYSTEM")
+ALLOCATION = os.environ.get("TACCJM_ALLOCATION")
+
+# Port to srat test servers on
+TEST_TACCJM_PORT = 8661
+TEST_JM_ID = 'test-taccjm'
+
+# TEST JM  to use throughout tests
+TEST_JM = None
+
+def_test_dir = Path(__file__).parent / ".test_dir"
+
+@pytest.fixture()
+def test_dir():
+    if def_test_dir.exists():
+        shutil.rmtree(def_test_dir)
+    def_test_dir.mkdir(exist_ok=True)
+    test_dir_path = Path(def_test_dir).absolute()
+    yield test_dir_path
+    try:
+        shutil.rmtree(test_dir_path)
+    except:
+        pass
+
+@pytest.fixture()
+def test_script(test_dir):
+    script_path = str(test_dir.absolute() / 'test_script.sh')
+    with open(script_path, 'w') as fp:
+        fp.write('#!/bin/bash\nsleep 5\necho foo\n')
+    yield script_path
+
+@pytest.fixture()
+def test_file(test_dir):
+    file_path = f'{test_dir}/hello.txt'
+    with open(file_path, 'w') as f:
+        f.write('Hello World!')
+    yield file_path
+
+def pytest_addoption(parser):
+    parser.addoption("--mfa", action="store",
+            default="012345", help="MFA token. Must be provided")
+
+@pytest.fixture
+def mfa(request):
+    return request.config.getoption("--mfa")
+
+def test_init(mfa):
+  runner = CliRunner()
+  result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                               'init', TEST_JM_ID, SYSTEM, USER, '--mfa', mfa])
+  assert result.exit_code == 0
+
+def test_find_server():
+  runner = CliRunner()
+  result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                               'find-server'])
+  assert result.exit_code == 0
+
+def test_list():
+  runner = CliRunner()
+  result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                               'list'])
+  assert result.exit_code == 0
+
+def test_allocations():
+  runner = CliRunner()
+  result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                               'allocations'])
+  assert result.exit_code == 0
+
+def test_queue():
+  runner = CliRunner()
+  result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                               'queue'])
+  assert result.exit_code == 0
+
+def test_scripts(test_script):
+  runner = CliRunner()
+  result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                               'scripts',
+                               '--jm_id', TEST_JM_ID,
+                               'deploy', f'{test_script}',
+                               '--rename', 'foo'])
+  assert result.exit_code == 0
+  assert len(result.output) == 45 # exactly one in list, the one we deployed
+  result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                               'scripts',
+                               '--jm_id', TEST_JM_ID,
+                               'deploy', f'{test_script}'])
+  assert result.exit_code == 0
+  assert len(result.output) == 80 # exactly one in list, the one we deployed
+  result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                               'scripts',
+                               '--jm_id', TEST_JM_ID,
+                               'list',
+                               '--match', 'foo|test_script'])
+  assert result.exit_code == 0
+  assert len(result.output) == 96 # exactly one in list, the one we deployed
+  result1 = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                               'scripts',
+                               '--jm_id', TEST_JM_ID,
+                               'run', 'foo'])
+  assert result1.exit_code == 0
+  result2 = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                               'scripts',
+                               '--jm_id', TEST_JM_ID,
+                               'run', f'{Path(test_script).stem}'])
+  assert result2.exit_code == 0
+  assert result1.output == result2.output
+
+def test_files(test_file, test_dir):
+    runner = CliRunner()
+    dirname = str(Path(test_dir).name)
+    fname = str(Path(test_file).name)
+    download_path = f'{test_dir}/{Path(test_file).stem}-down.txt'
+
+    # Remove. Don't care about result
+    result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                 'files',
+                                 '--jm_id', TEST_JM_ID,
+                                 'remove', fname])
+    result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                 'files',
+                                 '--jm_id', TEST_JM_ID,
+                                 'list', '--match', fname])
+    assert result.exit_code == 0
+    assert len(result.output) == 216
+    result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                 'files',
+                                 '--jm_id', TEST_JM_ID,
+                                 'upload', test_file, fname])
+    assert result.exit_code == 0
+    assert len(result.output) == 290
+
+    result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                 'files',
+                                 '--jm_id', TEST_JM_ID,
+                                 'peak', fname])
+    assert result.exit_code == 0
+    assert len(result.output) == 60
+
+    result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                 'files',
+                                 '--jm_id', TEST_JM_ID,
+                                 'download', fname, download_path])
+    assert result.exit_code == 0
+    with open(test_file, 'r') as f1, open(download_path, 'r') as f2:
+        assert f1.read() == f2.read()
+
+    result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                 'files',
+                                 '--jm_id', TEST_JM_ID,
+                                 'write', fname, 'goodbye!'])
+    assert len(result.output) == 290
+    result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                 'files',
+                                 '--jm_id', TEST_JM_ID,
+                                 'read', fname])
+    assert result.exit_code == 0
+    assert len(result.output) == 9
+
+    result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                 'files',
+                                 '--jm_id', TEST_JM_ID,
+                                 'remove', fname])
+    assert result.exit_code == 0
+    assert fname not in result.output
+    result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                 'files',
+                                 '--jm_id', TEST_JM_ID,
+                                 'restore', fname])
+    assert result.exit_code == 0
+    assert fname in result.output
+
+def test_apps(test_dir):
+    runner = CliRunner()
+    app_name = 'test-app'
+    app_dir = str((Path(test_dir) / app_name).absolute())
+
+    # Create template
+    result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                 'apps',
+                                 'template', app_name, '--dest_dir', test_dir])
+    assert result.exit_code == 0
+
+    # Deploy app
+    deploy_result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                 'apps',
+                                 'deploy', app_dir, '-o'])
+    assert deploy_result.exit_code == 0
+    assert len(deploy_result.output) == 1853
+
+    # TODO: Bug - this should fail but it doesn't
+    # Bad deploy - no overwrite
+    # deploy_result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+    #                              'apps',
+    #                              'deploy', app_dir])
+    # assert deploy_result.exit_code == 1
+
+    # Make sure app appears in list
+    result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                 'apps',
+                                 'list', '--match', app_name])
+    assert result.exit_code == 0
+    assert len(result.output) == 65
+
+    # Get ppplication config
+    get_result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                 'apps',
+                                 'get', app_name])
+    assert get_result.exit_code == 0
+    assert app_name in result.output
+
+def test_jobs(test_file, test_dir):
+    runner = CliRunner()
+    app_name = 'test-app'
+    job_name = f'{app_name}-test-job'
+    app_dir = str((Path(test_dir) / app_name).absolute())
+    job_config_path = str((Path(test_dir) / app_name / 'job.json').absolute())
+
+    # Create template app
+    result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                 'apps',
+                                 'template', app_name, '--dest_dir', test_dir])
+    assert result.exit_code == 0
+
+    # Edit job config input file
+    jc = {}
+    with open(job_config_path, 'r') as fp:
+        jc = json.load(fp)
+    jc['inputs']['input1'] = job_config_path
+    jc['allocation'] = ALLOCATION
+    with open(job_config_path, 'w') as fp:
+        json.dump(jc, fp)
+
+    # Deploy app
+    result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                 'apps',
+                                 'deploy', app_dir, '-o'])
+    assert result.exit_code == 0
+
+    deploy_result = runner.invoke(cli,
+                                  ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                   'jobs',
+                                   'deploy', '--config_file', job_config_path])
+    assert deploy_result.exit_code == 0
+
+    list_result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                 'jobs',
+                                 'list', '--match', job_name])
+    assert list_result.exit_code == 0
+    job_id = list_result.output.split('\n')[3][2:-2]
+    assert job_id.startswith('test-app-test-job')
+
+    submit_result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                 'jobs',
+                                 'submit', job_id])
+    assert submit_result.exit_code == 0
+
+    cancel_result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                 'jobs',
+                                 'cancel', job_id])
+    assert cancel_result.exit_code == 0
+
+    remove_result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                 'jobs',
+                                 'remove', job_id])
+    assert remove_result.exit_code == 0
+
+    list_result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                 'jobs',
+                                 'list', '--match', job_name])
+    assert list_result.exit_code == 0
+    assert job_id not in list_result.output
+
+    restore_result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                 'jobs',
+                                 'restore', job_id])
+    assert restore_result.exit_code == 0
+
+    list_result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                 'jobs',
+                                 'list', '--match', job_name])
+    assert list_result.exit_code == 0
+    assert job_id in list_result.output
+
+    remove_result = runner.invoke(cli, ['--server', 'localhost', str(TEST_TACCJM_PORT),
+                                 'jobs',
+                                 'remove', job_id])
+    assert remove_result.exit_code == 0
+
+

--- a/tests/test_taccjm.py
+++ b/tests/test_taccjm.py
@@ -481,8 +481,8 @@ def test_jobs():
         _ = tc.get_job(TEST_JM['jm_id'], 'bad_job')
 
     # Error - Deploy job with bad path specified
-    with pytest.raises(FileNotFoundError):
-        _ = tc.deploy_job(TEST_JM['jm_id'], job_config=job_config,
+    with pytest.raises(TACCJMError):
+        _ = tc.deploy_job(TEST_JM['jm_id'], job_config=None,
                 local_job_dir='/bad/path', stage=False, desc='Test Job')
 
     # Error - Write job file to bad dest_dir

--- a/tests/test_taccjm_client.py
+++ b/tests/test_taccjm_client.py
@@ -12,8 +12,8 @@ import posixpath
 from dotenv import load_dotenv
 from unittest.mock import patch
 
-from taccjm import taccjm as tc
-from taccjm.taccjm import TACCJMError
+from taccjm import taccjm_client as tc
+from taccjm.exceptions import TACCJMError
 from taccjm.utils import *
 from taccjm.constants import *
 

--- a/tests/test_taccjm_server.py
+++ b/tests/test_taccjm_server.py
@@ -281,7 +281,7 @@ def test_jobs():
     job_config['inputs']['input1'] = os.path.join(local_app_dir, 'input.txt')
     os.system(f"echo hello world > {job_config['inputs']['input1']}")
     response = hug.test.post(taccjm_server, f"{test_jm}/jobs/deploy",
-            {'job_config':job_config, 'local_job_dir':local_app_dir})
+            {'job_config':json.dumps(job_config), 'local_job_dir':local_app_dir})
     assert response.status == '200 OK'
     job_id = response.data['job_id']
 
@@ -357,7 +357,7 @@ def test_jobs():
     with patch.object(TACCJobManager, 'deploy_job',
             side_effect=ValueError('Mock value error.')):
         response = hug.test.post(taccjm_server, f"{test_jm}/jobs/deploy",
-                {'job_config':job_config})
+                {'job_config':json.dumps(job_config)})
         assert response.status == '400 Bad Request'
 
     # Mock write job data errors


### PR DESCRIPTION
Add:
+ Some basic boilerplate documentation.

Changes:
- Execute command functional change:
	- using an explicit Paramiko ``Channel`` to execute commands now
	instead of using `exec_command` function in the  ``Client``
	class.
	- Allows execution of background commands (as channel isnt
	  cosed) explicitly. Manage these channels later?
	- Reads in up to 1Mb of data. Implement different method later?
- To clean-up jobs with large amounts of inputs or applications with a
lot of files, move location of app and job inputs within a job
directory:
	- App contents go in to folder with name equal to name of
	application.
	- Job inputs go in 'inputs' directory.

Removed:
- Removed project.ini configuration file for apps and jobs. Just simpler
to have one json file for apps and jobs. Templating is overkill.

Tests:
- Tests modified to pass with changes.